### PR TITLE
refactor: replace `micromatch` with `picomatch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "colorette": "^2.0.20",
     "commander": "^12.1.0",
     "js-yaml": "^4.1.0",
-    "micromatch": "^4.0.8",
     "npm-package-arg": "^12.0.0",
-    "npm-registry-fetch": "^18.0.2"
+    "npm-registry-fetch": "^18.0.2",
+    "picomatch": "^4.0.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",
@@ -49,11 +49,11 @@
     "@sapphire/prettier-config": "^2.0.0",
     "@sapphire/ts-config": "^5.0.1",
     "@types/js-yaml": "^4.0.9",
-    "@types/micromatch": "^4.0.9",
     "@types/node": "^20.16.11",
     "@types/node-fetch": "^2.6.11",
     "@types/npm-package-arg": "^6.1.4",
     "@types/npm-registry-fetch": "^8.0.7",
+    "@types/picomatch": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^7.13.1",
     "@typescript-eslint/parser": "^7.13.1",
     "cz-conventional-changelog": "^3.3.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ const command = new Command()
   .version(packageJson.version)
   .option(
     '-n, --name <nameGlob>',
-    'A glob pattern that will determine which packages are deprecated. Anything that passes [Micromatch](https://www.npmjs.com/package/micromatch) will work here. For example set `*dev*` to match `13.2.0-dev.123a`.'
+    'A glob pattern that will determine which packages are deprecated. Anything that passes [picomatch](https://www.npmjs.com/package/picomatch) or [micromatch](https://www.npmjs.com/package/micromatch) will work here. For example set `*dev*` to match `13.2.0-dev.123a`.'
   )
   .option(
     '-d, --deprecate-dist-tag [deprecateDistTag]',

--- a/src/commands/deprecate.ts
+++ b/src/commands/deprecate.ts
@@ -3,7 +3,7 @@ import type { NpmRegistry, Options } from '#lib/interfaces';
 import { logVerboseError, logVerboseInfo } from '#lib/logVerbose';
 import { fetch, FetchResultTypes, QueryError } from '@sapphire/fetch';
 import { isNullish } from '@sapphire/utilities';
-import micromatch from 'micromatch';
+import picomatch from 'picomatch';
 import npa from 'npm-package-arg';
 import npmFetch from 'npm-registry-fetch';
 
@@ -49,6 +49,8 @@ export async function deprecatePackages(options: Options): Promise<void> {
   const fetchPromises: Promise<unknown>[] = [];
   let amountVersionsChanged = 0;
 
+  const isVersionMatch = picomatch(options.name, { nocase: true });
+
   for (const pkg of registryJsonFiles) {
     const distTags = Object.values(pkg['dist-tags']);
     const packageArg = npa(pkg.name);
@@ -60,7 +62,7 @@ export async function deprecatePackages(options: Options): Promise<void> {
 
       if (!options.deprecateDistTag && distTags.includes(version.version)) continue;
 
-      if (!micromatch.isMatch(version.version, options.name, { nocase: true })) continue;
+      if (!isVersionMatch(version.version)) continue;
 
       logVerboseInfo([`Deprecating version ${version.name}@${version.version}`], options.verbose);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -337,11 +337,11 @@ __metadata:
     "@sapphire/ts-config": "npm:^5.0.1"
     "@sapphire/utilities": "npm:^3.17.0"
     "@types/js-yaml": "npm:^4.0.9"
-    "@types/micromatch": "npm:^4.0.9"
     "@types/node": "npm:^20.16.11"
     "@types/node-fetch": "npm:^2.6.11"
     "@types/npm-package-arg": "npm:^6.1.4"
     "@types/npm-registry-fetch": "npm:^8.0.7"
+    "@types/picomatch": "npm:^3.0.1"
     "@typescript-eslint/eslint-plugin": "npm:^7.13.1"
     "@typescript-eslint/parser": "npm:^7.13.1"
     colorette: "npm:^2.0.20"
@@ -352,9 +352,9 @@ __metadata:
     eslint-plugin-prettier: "npm:^5.2.1"
     js-yaml: "npm:^4.1.0"
     lint-staged: "npm:^15.2.10"
-    micromatch: "npm:^4.0.8"
     npm-package-arg: "npm:^12.0.0"
     npm-registry-fetch: "npm:^18.0.2"
+    picomatch: "npm:^4.0.2"
     prettier: "npm:^3.3.3"
     typescript: "npm:^5.5.2"
   bin:
@@ -643,13 +643,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/braces@npm:*":
-  version: 3.0.1
-  resolution: "@types/braces@npm:3.0.1"
-  checksum: 10/3749f7673a03d498ddb2f199b222bb403e53e78ac05a599c757c2049703ece802602c78640af0ff826be0fd2ea8b03daff04ce18806ed739592302195b7a569b
-  languageName: node
-  linkType: hard
-
 "@types/conventional-commits-parser@npm:^5.0.0":
   version: 5.0.0
   resolution: "@types/conventional-commits-parser@npm:5.0.0"
@@ -663,15 +656,6 @@ __metadata:
   version: 4.0.9
   resolution: "@types/js-yaml@npm:4.0.9"
   checksum: 10/a0ce595db8a987904badd21fc50f9f444cb73069f4b95a76cc222e0a17b3ff180669059c763ec314bc4c3ce284379177a9da80e83c5f650c6c1310cafbfaa8e6
-  languageName: node
-  linkType: hard
-
-"@types/micromatch@npm:^4.0.9":
-  version: 4.0.9
-  resolution: "@types/micromatch@npm:4.0.9"
-  dependencies:
-    "@types/braces": "npm:*"
-  checksum: 10/324f4bcb4a7caa2048bdd650f442d2c24b5bf6bc95e4d63d4741bd234fdcf3cde140217bd477b2c02c7fb0034c7293037fd7b61429ace84e997dd3b4d3b2b2f7
   languageName: node
   linkType: hard
 
@@ -727,6 +711,13 @@ __metadata:
   version: 4.1.4
   resolution: "@types/npmlog@npm:4.1.4"
   checksum: 10/740f7431ccfc0e127aa8d162fe05c6ce8aa71290be020d179b2824806d19bd2c706c7e0c9a3c9963cefcdf2ceacb1dec6988c394c3694451387759dafe0aa927
+  languageName: node
+  linkType: hard
+
+"@types/picomatch@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@types/picomatch@npm:3.0.1"
+  checksum: 10/0fadfbd35d80c203d9c7979bc2291b10d3fe859e63a7e96da0b9e45e6d568e8d0b4e79bbf5bb775a478ef9f6b1db76228703b73fa0e242f19c35be8a939c3603
   languageName: node
   linkType: hard
 
@@ -2926,7 +2917,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.8, micromatch@npm:~4.0.8":
+"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:~4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:
@@ -3365,6 +3356,13 @@ __metadata:
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10/60c2595003b05e4535394d1da94850f5372c9427ca4413b71210f437f7b2ca091dbd611c45e8b37d10036fa8eade25c1b8951654f9d3973bfa66a2ff4d3b08bc
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "picomatch@npm:4.0.2"
+  checksum: 10/ce617b8da36797d09c0baacb96ca8a44460452c89362d7cb8f70ca46b4158ba8bc3606912de7c818eb4a939f7f9015cef3c766ec8a0c6bfc725fdc078e39c717
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Under the hood, `micromatch` is built directly on top of `picomatch`, and `micromatch.isMatch` is just an alias method:

https://github.com/micromatch/micromatch/blob/8bd704ec0d9894693d35da425d827819916be920/index.js#L128

```js
micromatch.isMatch = (str, patterns, options) => picomatch(patterns, options)(str);
```

The PR replaces `micromatch` with `picomatch`, and hoists the matcher to prevent internal regex being created over and over again during the nested `for` loop.